### PR TITLE
Improve namespace structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ _(This is a libary in alpha version, it's very likely to change)_
 (ns diagram-example
   (:require [structurizr-clj.core :refer [defmodel defstyles defviews defworkspace] :as structurizr]
             [structurizr-clj.shape :as structurizr.shape]
-            [structurizr-clj.tags :as structurizr.tags]))
+            [structurizr-clj.style :as structurizr.style]
+            [structurizr-clj.tags :as structurizr.tags]
+            [structurizr-clj.view :as structurizr.view]
 
 (defworkspace example
   [workspace (structurizr/new-workspace "Getting Started" "This is a model of my software system")]
@@ -28,22 +30,22 @@ _(This is a libary in alpha version, it's very likely to change)_
     (structurizr/uses user software-system "Uses")
     (structurizr/uses yo-service database "Persists data" "Datomic")
     (defviews [views                (structurizr/views workspace)
-               containers-view      (structurizr/create-container-view views software-system "Containers" "An example of Container context diagram")
-               software-system-view (structurizr/create-system-context-view views software-system "System Context" "An example of a System Context diagram")]
-      (defstyles [styles (structurizr/styles views)]
-        (doto (structurizr/add-element-style styles structurizr.tags/person)
-              (structurizr/shape structurizr.shape/person))
-        (doto (structurizr/add-element-style styles "Database")
-              (structurizr/shape structurizr.shape/cylinder))
-        (doto (structurizr/add-element-style styles "Main")
-              (structurizr/background "#800080")
-              (structurizr/color "#ffffff")))
+               containers-view      (structurizr.view/create-container views software-system "Containers" "An example of Container context diagram")
+               software-system-view (structurizr.view/create-system-context views software-system "System Context" "An example of a System Context diagram")]
+      (defstyles [styles (structurizr.view/styles views)]
+        (doto (structurizr.style/add-element styles structurizr.tags/person)
+              (structurizr.style/shape structurizr.shape/person))
+        (doto (structurizr.style/add-element styles "Database")
+              (structurizr.style/shape structurizr.shape/cylinder))
+        (doto (structurizr.style/add-element styles "Main")
+              (structurizr.style/background "#800080")
+              (structurizr.style/color "#ffffff")))
       (doto software-system-view
-            structurizr/add-all-software-systems
-            structurizr/add-all-people)
+            structurizr.view/add-software-systems
+            structurizr.view/add-people)
       (doto containers-view
-            structurizr/add-all-software-systems
-            structurizr/add-all-containers))))
+            structurizr.view/add-software-systems
+            structurizr.view/add-containers))))
 ```
 
 <p align="center">
@@ -76,13 +78,14 @@ Structurizr Java supports renders to PlantUML, Mermaid, JSON and publish the wor
 ``` clojure
 (ns render-example
   (:require [structurizr-clj.core :refer [defmodel defviews defworkspace] :as structurizr]
-            [structurizr-clj.render :as structurizr.render]))
+            [structurizr-clj.render :as structurizr.render]
+            [structurizr-clj.view :as structurizr.view]))
 
 ;; Asuming an example workspace is define
 (def views (structurizr/views example))
 
 ;; There might be many system contex views define, in this case it takes the first one
-(def system-context-view (first (structurizr.render/system-context-views views))) 
+(def system-context-view (first (structurizr.view/system-contexts views))) 
 
 (structurizr.render/mermaid system-context-view) ;; Returns the string mermaid code
 (structurizr.render/mermaid-writer system-context-view "path/mermaid.txt") ;; Writes a file with the mermaid code to the given path
@@ -94,13 +97,14 @@ Structurizr Java supports renders to PlantUML, Mermaid, JSON and publish the wor
 ``` clojure
 (ns render-example
   (:require [structurizr-clj.core :refer [defmodel defviews defworkspace] :as structurizr]
-            [structurizr-clj.render :as structurizr.render]))
+            [structurizr-clj.render :as structurizr.render]
+            [structurizr-clj.view :as structurizr.view]))
 
 ;; Asuming an example workspace is define
 (def views (structurizr/views example))
 
 ;; There might be many system contex views define, in this case it takes the first one
-(def system-context-view (first (structurizr.render/system-context-views views))) 
+(def system-context-view (first (structurizr.view/system-contexts views))) 
 
 (structurizr.render/plantuml system-context-view) ;; Returns the string plantuml code
 (structurizr.render/plantuml-writer system-context-view "path/plantuml.txt") ;; Writes a file with the plantuml code to the given path

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -e
+
+#!/bin/sh
+read -r -p "Enter the current build version (without snapshot): " currentVersion
+read -r -p "Enter the version to release: " releaseVersion
+read -r -p "Enter the next build version (without snapshot): " nextVersion
+echo "Starting to release structurizr-clj $releaseVersion" && \
+git pull --rebase && \
+lein clean && \
+lein test && \
+echo "Changing Build version to $releaseVersion" && \
+sed -i "s/\"${currentVersion}-SNAPSHOT\"/\"${releaseVersion}\"/g" project.clj && \
+echo "Pushing changes to git" && \
+git add project.clj && \
+git commit -m "Version ${releaseVersion}" && \
+git push && \
+echo "Will create and push git tags.." && \
+git tag -a "${releaseVersion}" -m "Released ${releaseVersion}" && \
+git push --tags && \
+echo "Updating version to ${nextVersion}" && \
+sed -i "s/\"${releaseVersion}\"/\"${nextVersion}-SNAPSHOT\"/g" project.clj && \
+git add project.clj
+git commit -m "Version ${nextVersion}-SNAPSHOT" && \
+git push && \
+echo "Release of structurizr-clj $releaseVersion completed successfully!"

--- a/resources/json-workspaces/views-workspace-test.json
+++ b/resources/json-workspaces/views-workspace-test.json
@@ -1,0 +1,106 @@
+{
+  "id" : 0,
+  "name" : "My Workspace",
+  "description" : " My Workspace Architecture",
+  "configuration" : { },
+  "model" : {
+    "softwareSystems" : [ {
+      "id" : "1",
+      "tags" : "Element,Software System",
+      "name" : "My System",
+      "description" : "System",
+      "location" : "Unspecified",
+      "containers" : [ {
+        "id" : "3",
+        "tags" : "Element,Container,Database",
+        "name" : "Database",
+        "description" : "Main database",
+        "technology" : "Datomic"
+      }, {
+        "id" : "2",
+        "tags" : "Element,Container,Main",
+        "name" : "Yo",
+        "description" : "Service",
+        "relationships" : [ {
+          "id" : "5",
+          "tags" : "Relationship",
+          "sourceId" : "2",
+          "destinationId" : "3",
+          "description" : "Persists data",
+          "technology" : "Datomic"
+        } ],
+        "technology" : "Clojure",
+        "components" : [ {
+          "id" : "4",
+          "tags" : "Element,Component",
+          "name" : "HTTP",
+          "description" : "Allows http request calls",
+          "technology" : "Component",
+          "size" : 0
+        } ]
+      } ]
+    } ]
+  },
+  "documentation" : { },
+  "views" : {
+    "systemLandscapeViews" : [ {
+      "description" : "My services",
+      "key" : "System Landscape view",
+      "enterpriseBoundaryVisible" : true,
+      "elements" : [ {
+        "id" : "1",
+        "x" : 0,
+        "y" : 0
+      } ]
+    } ],
+    "systemContextViews" : [ {
+      "softwareSystemId" : "1",
+      "description" : "My services",
+      "key" : "System Context view",
+      "enterpriseBoundaryVisible" : true,
+      "elements" : [ {
+        "id" : "1",
+        "x" : 0,
+        "y" : 0
+      } ]
+    } ],
+    "containerViews" : [ {
+      "softwareSystemId" : "1",
+      "description" : "My services",
+      "key" : "Containers view",
+      "externalSoftwareSystemBoundariesVisible" : false,
+      "relationships" : [ {
+        "id" : "5"
+      } ],
+      "elements" : [ {
+        "id" : "2",
+        "x" : 0,
+        "y" : 0
+      }, {
+        "id" : "3",
+        "x" : 0,
+        "y" : 0
+      } ]
+    } ],
+    "componentViews" : [ {
+      "description" : "HTTP interaction",
+      "key" : "Component view",
+      "containerId" : "2",
+      "externalContainerBoundariesVisible" : false,
+      "elements" : [ {
+        "id" : "3",
+        "x" : 0,
+        "y" : 0
+      }, {
+        "id" : "4",
+        "x" : 0,
+        "y" : 0
+      } ]
+    } ],
+    "configuration" : {
+      "branding" : { },
+      "styles" : { },
+      "terminology" : { }
+    }
+  }
+}

--- a/src/structurizr_clj/core.clj
+++ b/src/structurizr_clj/core.clj
@@ -5,12 +5,13 @@
 ;; Tags
 
 (defn add-tags
-  [item tags]
+  "Add given tags to given element"
+  [element tags]
   (if (empty? tags)
-    item
+    element
     (do
-      (.addTags item (into-array tags))
-      item)))
+      (.addTags element (into-array tags))
+      element)))
 
 ;; Workspace
 
@@ -21,6 +22,11 @@
 (defn model
   [workspace]
   (.getModel workspace))
+
+(defn views
+  "Get views from workspace"
+  [workspace]
+  (.getViews workspace))
 
 ;; Model
 
@@ -58,86 +64,8 @@
   ([node-a node-b description technology]
    (.uses node-a node-b description technology)))
 
-;; Views
-
-(defn views
-  "Get views from workspace"
-  [workspace]
-  (.getViews workspace))
-
-(defn create-system-landscape-view
-  "Creates SystemLandscape view "
-  [views  key description]
-  (.createSystemLandscapeView views key description))
-
-(defn create-system-context-view
-  "Creates SystemContextView for given software-system"
-  [views software-system key description]
-  (.createSystemContextView views software-system key description))
-
-(defn create-container-view
-  "Creates ContainerView for given software-system"
-  [views software-system key description]
-  (.createContainerView views software-system key description))
-
-(defn create-component-view
-  "Creates ComponentView for given container"
-  [views container key description]
-  (.createComponentView views container key description))
-
-(defn configuration
-  "Gets configuration for given views"
-  [views]
-  (.getConfiguration views))
-
-(defn styles
-  "Get styles HashSet for given views"
-  [views]
-  (.getStyles (configuration views)))
-
-(defn add-element-style
-  [styles tag]
-  (.addElementStyle styles tag))
-
-(defn background
-  "Add background to style-item"
-  [style-item hex]
-  (.background style-item hex))
-
-(defn color
-  "Add color to style-item"
-  [style-item hex]
-  (.color style-item hex))
-
-(defn shape
-  "Add shape to style-item"
-  [style-item shape-name]
-  (.shape style-item  shape-name))
-
-;; Renders
-
-(defn add-all-people
-  [view]
-  (.addAllPeople view))
-
-(defn add-all-software-systems
-  [view]
-  (.addAllSoftwareSystems view))
-
-(defn add-all-containers
-  [view]
-  (.addAllContainers view))
-
-(defn add-all-components
-  [view]
-  (.addAllComponents view))
-
-(defn add-all-elements
-  [view]
-  (.addAllElements view))
-
 (defmacro defworkspace
-  "NOTE: Rework todo, Creates a workspace and binds it to Var name"
+  "Creates a workspace and binds it to Var name"
   [& params]
   (let [workspace-name                   (first params)
         [workspace-binding :as bindings] (second params)

--- a/src/structurizr_clj/render.clj
+++ b/src/structurizr_clj/render.clj
@@ -4,26 +4,6 @@
            (com.structurizr.io.plantuml StructurizrPlantUMLWriter)
            (com.structurizr.util WorkspaceUtils)))
 
-(defn get-key
-  [view]
-  (.getKey view))
-
-(defn system-landscape-views
-  [views]
-  (.getSystemLandscapeViews views))
-
-(defn system-context-views
-  [views]
-  (.getSystemContextViews views))
-
-(defn container-views
-  [views]
-  (.getContainerViews views))
-
-(defn component-views
-  [views]
-  (.getComponentViews views))
-
 (defn plantuml
   "Receives a structurizr.View and returns the plantUML encoding as string"
   [view]

--- a/src/structurizr_clj/style.clj
+++ b/src/structurizr_clj/style.clj
@@ -1,0 +1,20 @@
+(ns structurizr-clj.style)
+
+(defn add-element
+  [styles tag]
+  (.addElementStyle styles tag))
+
+(defn background
+  "Add background to style-item"
+  [style-item hex]
+  (.background style-item hex))
+
+(defn color
+  "Add color to style-item"
+  [style-item hex]
+  (.color style-item hex))
+
+(defn shape
+  "Add shape to style-item"
+  [style-item shape-name]
+  (.shape style-item  shape-name))

--- a/src/structurizr_clj/view.clj
+++ b/src/structurizr_clj/view.clj
@@ -1,0 +1,86 @@
+(ns structurizr-clj.view)
+
+(defn configuration
+  "Gets configuration for given views"
+  [views]
+  (.getConfiguration views))
+
+(defn get-key
+  [view]
+  (.getKey view))
+
+(defn styles
+  "Get styles HashSet for given views"
+  [views]
+  (.getStyles (configuration views)))
+
+(defn system-landscapes
+  [views]
+  (.getSystemLandscapeViews views))
+
+(defn system-contexts
+  [views]
+  (.getSystemContextViews views))
+
+(defn containers
+  [views]
+  (.getContainerViews views))
+
+(defn components
+  [views]
+  (.getComponentViews views))
+
+(defn create-system-landscape
+  "Creates SystemLandscape view "
+  [views  key description]
+  (.createSystemLandscapeView views key description))
+
+(defn create-system-context
+  "Creates SystemContextView for given software-system"
+  [views software-system key description]
+  (.createSystemContextView views software-system key description))
+
+(defn create-container
+  "Creates ContainerView for given software-system"
+  [views software-system key description]
+  (.createContainerView views software-system key description))
+
+(defn create-component
+  "Creates ComponentView for given container"
+  [views container key description]
+  (.createComponentView views container key description))
+
+(defn add-element
+  "Adds te given element to this view, including relationships to/from that element"
+  [view element]
+  (.add view element))
+
+(defn remove-element
+  "Removes an individual element from this view"
+  [view element]
+  (.remove view element))
+
+(defn add-people
+  "Adds all person elements to the view"
+  [view]
+  (.addAllPeople view))
+
+(defn add-software-systems
+  "Adds all software-systems to the view"
+  [view]
+  (.addAllSoftwareSystems view))
+
+(defn add-containers
+  "Adds all containers to the view"
+  [view]
+  (.addAllContainers view))
+
+(defn add-components
+  "Adds all components to the view"
+  [view]
+  (.addAllComponents view))
+
+(defn add-elements
+  "Adds all elements to the view"
+  [view]
+  (.addAllElements view))

--- a/src/structurizr_clj/view.clj
+++ b/src/structurizr_clj/view.clj
@@ -32,7 +32,7 @@
 
 (defn create-system-landscape
   "Creates SystemLandscape view "
-  [views  key description]
+  [views key description]
   (.createSystemLandscapeView views key description))
 
 (defn create-system-context
@@ -84,4 +84,3 @@
   "Adds all components to the view"
   [view]
   (.addAllComponents view))
-

--- a/src/structurizr_clj/view.clj
+++ b/src/structurizr_clj/view.clj
@@ -50,15 +50,20 @@
   [views container key description]
   (.createComponentView views container key description))
 
+(defn remove-element
+  "Removes an individual element from this view"
+  [view element]
+  (.remove view element))
+
 (defn add-element
   "Adds te given element to this view, including relationships to/from that element"
   [view element]
   (.add view element))
 
-(defn remove-element
-  "Removes an individual element from this view"
-  [view element]
-  (.remove view element))
+(defn add-elements
+  "Adds all elements to the view"
+  [view]
+  (.addAllElements view))
 
 (defn add-people
   "Adds all person elements to the view"
@@ -80,7 +85,3 @@
   [view]
   (.addAllComponents view))
 
-(defn add-elements
-  "Adds all elements to the view"
-  [view]
-  (.addAllElements view))

--- a/test/structurizr_clj/core_test.clj
+++ b/test/structurizr_clj/core_test.clj
@@ -2,7 +2,9 @@
   (:require [clojure.test :refer :all]
             [structurizr-clj.core :refer [defmodel defstyles defviews defworkspace] :as structurizr]
             [structurizr-clj.shape :as structurizr.shape]
-            [structurizr-clj.tags :as structurizr.tags]))
+            [structurizr-clj.style :as structurizr.style]
+            [structurizr-clj.tags :as structurizr.tags]
+            [structurizr-clj.view :as structurizr.view]))
 
 (defworkspace my-workspace
   [workspace (structurizr/new-workspace "Getting Started" "This is a model of my software system")]
@@ -10,27 +12,30 @@
              user            (structurizr/add-person model "User" "A user of my software system" [structurizr.tags/person])
              software-system (structurizr/add-software-system model "Software System" "My software system")]
             [yo-service (structurizr/add-container software-system "Yo" "Service" "Clojure" ["Main"])
+             tu-service (structurizr/add-container software-system "Tu" "Service" "Clojure")
              database   (structurizr/add-container software-system "Database" "Main database" "Datomic" ["Database"])]
             []
     (structurizr/uses user software-system "Uses")
+    (structurizr/uses tu-service yo-service "Uses")
     (structurizr/uses yo-service database "Persists data" "Datomic")
     (defviews [views                (structurizr/views workspace)
-               containers-view      (structurizr/create-container-view views software-system "Containers" "An example of Container context diagram")
-               software-system-view (structurizr/create-system-context-view views software-system "System Context" "An example of a System Context diagram")]
-      (defstyles [styles (structurizr/styles views)]
-        (doto (structurizr/add-element-style styles structurizr.tags/person)
-              (structurizr/shape structurizr.shape/person))
-        (doto (structurizr/add-element-style styles "Database")
-              (structurizr/shape structurizr.shape/cylinder))
-        (doto (structurizr/add-element-style styles "Main")
-              (structurizr/background "#800080")
-              (structurizr/color "#ffffff")))
+               containers-view      (structurizr.view/create-container views software-system "Containers" "An example of Container context diagram")
+               software-system-view (structurizr.view/create-system-context views software-system "System Context" "An example of a System Context diagram")]
+      (defstyles [styles (structurizr.view/styles views)]
+        (doto (structurizr.style/add-element styles structurizr.tags/person)
+              (structurizr.style/shape structurizr.shape/person))
+        (doto (structurizr.style/add-element styles "Database")
+              (structurizr.style/shape structurizr.shape/cylinder))
+        (doto (structurizr.style/add-element styles "Main")
+              (structurizr.style/background "#800080")
+              (structurizr.style/color "#ffffff")))
       (doto software-system-view
-            structurizr/add-all-software-systems
-            structurizr/add-all-people)
+            structurizr.view/add-software-systems
+            (structurizr.view/add-element user))
       (doto containers-view
-            structurizr/add-all-software-systems
-            structurizr/add-all-containers))))
+            structurizr.view/add-software-systems
+            structurizr.view/add-containers
+            (structurizr.view/remove-element tu-service)))))
 
 (deftest workspace-test
   (testing "Nothing breaks and the workspace is a com.structurizr.Workspace"
@@ -43,3 +48,4 @@
   (testing "Client returns a structurizr client"
     (is (= com.structurizr.api.StructurizrClient (class client)))
     (is (= "http://localhost" (.getUrl client-2)))))
+

--- a/test/structurizr_clj/render_test.clj
+++ b/test/structurizr_clj/render_test.clj
@@ -1,52 +1,17 @@
 (ns structurizr-clj.render-test
   (:require [clojure.java.io :as io]
             [clojure.test :refer :all]
-            [structurizr-clj.core :refer [defmodel defviews defworkspace] :as structurizr]
-            [structurizr-clj.render :as structurizr.render]))
+            [structurizr-clj.core :as structurizr]
+            [structurizr-clj.render :as structurizr.render]
+            [structurizr-clj.view :as structurizr.view]))
 
-(defworkspace my-workspace
-  [workspace (structurizr/new-workspace "My Workspace" " My Workspace Architecture")]
-  (defmodel [model           (structurizr/model workspace)
-             software-system (structurizr/add-software-system model "My System" "System")]
-            [yo-service (structurizr/add-container software-system "Yo" "Service" "Clojure" ["Main"])
-             database   (structurizr/add-container software-system "Database" "Main database" "Datomic" ["Database"])]
-            [http (structurizr/add-component yo-service "HTTP" "Allows http request calls" "Component")]
-    (structurizr/uses yo-service database "Persists data" "Datomic")
-    (defviews [views                 (structurizr/views workspace)
-               system-landscape-view (structurizr/create-system-landscape-view views "System Landscape view" "My services")
-               system-context-view   (structurizr/create-system-context-view views software-system "System Context view" "My services")
-               containers-view       (structurizr/create-container-view views software-system "Containers view" "My services")
-               component-view        (structurizr/create-component-view views yo-service "Component view" "HTTP interaction")]
-      (doto system-landscape-view
-            structurizr/add-all-software-systems)
-      (doto system-context-view
-            structurizr/add-all-software-systems
-            structurizr/add-all-elements)
-      (doto containers-view
-            structurizr/add-all-software-systems
-            structurizr/add-all-containers)
-      (doto component-view
-            structurizr/add-all-containers
-            structurizr/add-all-components))))
-
-(def tmp
-  (str (.toString (io/file (System/getProperty "java.io.tmpdir"))) "/"))
-
+(def workspace (structurizr.render/json->workspace "resources/json-workspaces/views-workspace-test.json"))
+(def tmp (str (.toString (io/file (System/getProperty "java.io.tmpdir"))) "/"))
 (def plantuml-path (str tmp "plantuml-structurizr.txt"))
 (def mermaid-path (str tmp "mermaid-structurizr.txt"))
-(def views (structurizr/views my-workspace))
-(def system-context-view (first (structurizr.render/system-context-views views)))
-(def container-view (first (structurizr.render/container-views views)))
-
-(deftest get-key-test
-  (is (= "Containers view" (structurizr.render/get-key container-view))))
-
-(deftest get-views-functions-test
-  (is (= com.structurizr.view.SystemLandscapeView (class (first (structurizr.render/system-landscape-views views)))))
-  (is (= com.structurizr.view.SystemContextView (class (first (structurizr.render/system-context-views views)))))
-  (is (= com.structurizr.view.ContainerView (class (first (structurizr.render/container-views views)))))
-  (is (= com.structurizr.view.ComponentView (class (first (structurizr.render/component-views views))))))
-
+(def views (structurizr/views workspace))
+(def system-context-view (first (structurizr.view/system-contexts views)))
+(def container-view (first (structurizr.view/containers views)))
 (def plantuml-str "@startuml(id=Containers_view)\ntitle My System - Containers\ncaption My services\n\nskinparam {\n  shadowing false\n  arrowFontSize 10\n  defaultTextAlignment center\n  wrapWidth 200\n  maxMessageSize 100\n}\nhide stereotype\nskinparam rectangle<<2>> {\n  BackgroundColor #dddddd\n  FontColor #000000\n  BorderColor #9A9A9A\n}\nskinparam rectangle<<3>> {\n  BackgroundColor #dddddd\n  FontColor #000000\n  BorderColor #9A9A9A\n}\npackage \"My System\\n[Software System]\" {\n  rectangle \"==Database\\n<size:10>[Container: Datomic]</size>\\n\\nMain database\" <<3>> as 3\n  rectangle \"==Yo\\n<size:10>[Container: Clojure]</size>\\n\\nService\" <<2>> as 2\n}\n2 .[#707070].> 3 : \"Persists data\\n<size:8>[Datomic]</size>\"\n@enduml")
 (def mermaid-str "graph TB\n  linkStyle default fill:#ffffff\n  subgraph boundary [My System]\n    3[\"<div style='font-weight: bold'>Database</div><div style='font-size: 70%; margin-top: 0px'>[Container: Datomic]</div><div style='font-size: 80%; margin-top:10px'>Main database</div>\"]\n    style 3 fill:#dddddd,stroke:#9a9a9a,color:#000000\n    2[\"<div style='font-weight: bold'>Yo</div><div style='font-size: 70%; margin-top: 0px'>[Container: Clojure]</div><div style='font-size: 80%; margin-top:10px'>Service</div>\"]\n    style 2 fill:#dddddd,stroke:#9a9a9a,color:#000000\n  end\n  style boundary fill:#ffffff,stroke:#000000,color:#000000\n  2-. \"<div>Persists data</div><div style='font-size: 70%'>[Datomic]</div>\" .->3\n")
 
@@ -71,7 +36,6 @@
         _json          (structurizr.render/workspace->json my-workspace path)
         my-workspace-2 (structurizr.render/json->workspace path)
         my-workspace-3 (structurizr.render/json->workspace "resources/json-workspaces/my-workspace-test.json")]
-
     (is (= (.getName my-workspace) (.getName my-workspace-2)))
     (is (= (.getDescription my-workspace) (.getDescription my-workspace-2)))
     (is (= "Getting Started" (.getName my-workspace-3)))))

--- a/test/structurizr_clj/render_test.clj
+++ b/test/structurizr_clj/render_test.clj
@@ -33,9 +33,9 @@
 
 (deftest json-test
   (let [path           (str tmp "/my-workspace-test.json")
-        _json          (structurizr.render/workspace->json my-workspace path)
+        _json          (structurizr.render/workspace->json workspace path)
         my-workspace-2 (structurizr.render/json->workspace path)
         my-workspace-3 (structurizr.render/json->workspace "resources/json-workspaces/my-workspace-test.json")]
-    (is (= (.getName my-workspace) (.getName my-workspace-2)))
-    (is (= (.getDescription my-workspace) (.getDescription my-workspace-2)))
+    (is (= (.getName workspace) (.getName my-workspace-2)))
+    (is (= (.getDescription workspace) (.getDescription my-workspace-2)))
     (is (= "Getting Started" (.getName my-workspace-3)))))

--- a/test/structurizr_clj/view_test.clj
+++ b/test/structurizr_clj/view_test.clj
@@ -1,0 +1,18 @@
+(ns structurizr-clj.view-test
+  (:require [clojure.test :refer :all]
+            [structurizr-clj.core :as structurizr]
+            [structurizr-clj.render :as structurizr.render]
+            [structurizr-clj.view :as structurizr.view]))
+
+(def workspace (structurizr.render/json->workspace "resources/json-workspaces/views-workspace-test.json"))
+(def views (structurizr/views workspace))
+(def container-view (first (structurizr.view/containers views)))
+
+(deftest get-key-test
+  (is (= "Containers view" (structurizr.view/get-key container-view))))
+
+(deftest get-functions-test
+  (is (= com.structurizr.view.SystemLandscapeView (class (first (structurizr.view/system-landscapes views)))))
+  (is (= com.structurizr.view.SystemContextView (class (first (structurizr.view/system-contexts views)))))
+  (is (= com.structurizr.view.ContainerView (class (first (structurizr.view/containers views)))))
+  (is (= com.structurizr.view.ComponentView (class (first (structurizr.view/components views))))))


### PR DESCRIPTION
## BREAKING CHANGES
This PR introduces two new namespaces `view` and `style`. The reasoning behind it is that everything was inside the core ns and there was no structure or naming pattern in the functions. In addition, it's a visual help when reading or writing the diagram code, it's easier to understand `(structurizr.style/background)` than `(structurizr.background)`, this is because background could mean many things and by adding the `style` suffix then is explicit that the code is referring to the style.

| *structurizr-clj.core*       | *structurizr-clj.view*  |
|------------------------------|-------------------------|
| create-system-landscape-view | create-system-landscape |
| create-system-context-view   | create-system-context   |
| create-container-view        | create-container        |
| create-component-view        | create-component        |
| add-all-software-systems     | add-software-systems    |
| add-all-containers           | add-containers          |
| add-all-components           | add-components          |
| add-all-people               | add-people              |
| n/a                          | add-element             |
| n/a                          | remove-element          |


| *structurizr-clj.render* | *structurizr-clj.view* |
|--------------------------|------------------------|
| system-landscape-views   | system-landscapes      |
| system-context-views     | system-contexts        |
| container-views          | containers             |
| component-views          | components             |
| get-key                  | get-key                |
| configuration            | configuration          |

| *structurizr-clj.core* | *structurizr-clj.style* |
|------------------------|-------------------------|
| background             | background              |
| add-element-style      | add-element             |
| color                  | color                   |
| shape                  | shape                   |

